### PR TITLE
LIME-834 updating support link to one-login

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -30,7 +30,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: "beta"
-    content: "Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://signin.account.gov.uk/contact-us\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella."
+    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i''w wella.'
   footerNavItems:
     meta:
       items:
@@ -42,12 +42,12 @@ govuk:
           text: "Telerau ac amodau"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Hysbysiad preifatrwydd"
-        - href: "https://signin.account.gov.uk/contact-us"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Cefnogaeth"
   copyright:
     text: "© Hawlfraint y goron"
   contentLicence:
-    html: "Mae’r holl gynnwys ar gael o dan <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/\" rel=\"licence\">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol"
+    html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="licence">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
 error:
   unrecoverable:
     title: "Mae'n ddrwg gennym, mae problem"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -13,7 +13,7 @@ pageNotFound:
     - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
 
 sessionEnded:
   title: "Sesiwn wedi dod i ben"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -1,11 +1,10 @@
-
 buttons:
   next: Continue
   cancel: Cancel
 govuk:
   serviceName: Prove your identity
   backLink: Back
-  errorSummaryTitle: There’s a problem
+  errorSummaryTitle: There's a problem
   error: Error
   warning: Warning
   skipLink: Skip to main content
@@ -14,16 +13,16 @@ govuk:
       title: "Cookies on GOV.UK One Login"
       heading: "Cookies on GOV.UK One Login"
       paragraph1: "We use some essential cookies to make this service work."
-      paragraph2: "We’d also like to use analytics cookies so we can understand how you use the service and make improvements."
+      paragraph2: "We'd also like to use analytics cookies so we can understand how you use the service and make improvements."
       buttonAcceptText: "Accept analytics cookies"
       buttonRejectText: "Reject analytics cookies"
       linkViewCookiesText: "View cookies"
       cookieBannerHideLink: "Hide this message"
       cookieBannerAccept:
-        paragraph1: "You’ve accepted additional cookies. You can "
+        paragraph1: "You've accepted additional cookies. You can "
         paragraph2: " at any time."
       cookieBannerReject:
-        paragraph1: "You’ve rejected additional cookies. You can "
+        paragraph1: "You've rejected additional cookies. You can "
         paragraph2: " at any time."
       changeCookiePreferencesLink: "change your cookie settings"
     cookieText: "GOV.UK uses cookies to make the site simpler."
@@ -31,7 +30,7 @@ govuk:
     cookieLinkText: "Find out more about cookies"
   phaseBanner:
     tag: beta
-    content: This is a new service – your <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   footerNavItems:
     meta:
       items:
@@ -43,12 +42,12 @@ govuk:
           text: Terms and conditions
         - href: https://signin.account.gov.uk/privacy-notice
           text: Privacy notice
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login
           text: Support
   copyright:
     text: "© Crown copyright"
   contentLicence:
-    html: "All content is available under the <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"licence\">Open Government Licence v3.0</a>, except where otherwise stated"
+    html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Open Government Licence v3.0</a>, except where otherwise stated'
 
 error:
   unrecoverable:

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,4 +1,3 @@
-
 error:
   title: Sorry, there is a problem with the service
   content:
@@ -15,9 +14,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
-
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
 
 sessionEnded:
   title: Session expired
-

--- a/test/browser/features/fraud.feature
+++ b/test/browser/features/fraud.feature
@@ -31,3 +31,13 @@ Feature: Happy path
       | page           |
       | ThirdParty     |
       | Privacy Policy |
+
+  @mock-api:fraud-success
+  Scenario Outline: Check support links
+    Given they have started the Fraud journey
+    And they can see the check page
+    And they click Footer <link> and assert I have been redirected correctly
+
+    Examples:
+      | link           |
+      | Support        |

--- a/test/browser/pages/check.js
+++ b/test/browser/pages/check.js
@@ -20,6 +20,9 @@ module.exports = class PlaywrightDevPage {
     this.continueButton = this.page.locator("button", {
       hasText: " Continue ",
     });
+    this.supportLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[5]/a"
+    );
   }
 
   isCurrentPage() {
@@ -52,6 +55,13 @@ module.exports = class PlaywrightDevPage {
         "Privacy notice - GOV.UK One Login"
       );
     }
+  }
+  async assertFooterLink() {
+    await this.supportLink.click();
+    await this.page.waitForTimeout(2000); //waitForNavigation and waitForLoadState do not work in this case
+    expect(await this.page.title()).to.not.equal(
+      "Page not found - GOV.UK One Login"
+    );
   }
 
   async waitForSpinner() {

--- a/test/browser/step_definitions/fraud.js
+++ b/test/browser/step_definitions/fraud.js
@@ -32,3 +32,14 @@ Given(
     await checkPage.assertPrivacyTabs(linkName);
   }
 );
+
+Given(
+  /^they click Footer (.*) and assert I have been redirected correctly$/,
+  async function (linkName) {
+    const checkPage = new CheckPage(this.page);
+
+    expect(checkPage.isCurrentPage()).to.be.true;
+
+    await checkPage.assertFooterLink(linkName);
+  }
+);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The support link has been changed to the new one-login version.

### Why did it change

Due to contact centre being onboarded to one-login.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-834](https://govukverify.atlassian.net/browse/LIME-834)

## Checklists

### Environment variables or secrets




[LIME-834]: https://govukverify.atlassian.net/browse/LIME-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ