### PR TITLE
LIME-834: Overriding common express error pages

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -2,35 +2,36 @@ buttons:
   next: "Parhau"
   cancel: "Canslo"
 govuk:
+  phaseBanner:
+    tag: beta
+    content: Mae hwn yn wasanaeth newydd – <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">bydd eich adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   serviceName: "Profi pwy ydych chi"
   backLink: "Yn ôl"
   errorSummaryTitle: "Mae problem"
   error: "Gwall"
   warning: "Rhybudd"
   skipLink: "Neidio i'r prif gynnwys"
+  betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: beta
+    betaBannerContentHTML: Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">adborth (agor mewn tab newydd)</a>  yn ein helpu i''w wella.
   cookie:
     cookieBanner:
-      title: "Cwcis ar GOV.UK One Login"
-      heading: "Cwcis ar GOV.UK One Login"
-      paragraph1: "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio."
-      paragraph2: "Hoffem hefyd ddefnyddio cwcis dadansoddi er mwyn i ni allu deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau."
-      buttonAcceptText: "Derbyn cwcis dadansoddi"
-      buttonRejectText: "Gwrthod cwcis dadansoddi"
-      linkViewCookiesText: "Gweld cwcis"
-      cookieBannerHideLink: "Cuddio'r neges yma"
+      title: Cwcis ar GOV.UK One Login
+      heading: Cwcis ar GOV.UK One Login
+      paragraph1: Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio.
+      paragraph2: Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau.
+      changeCookiePreferencesLink: " newid eich gosodiadau cwcis"
       cookieBannerAccept:
-        paragraph1: "Rydych wedi derbyn cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
+        paragraph1: Rydych wedi derbyn cwcis ychwanegol. Gallwch
+        paragraph2: unrhyw bryd.
       cookieBannerReject:
-        paragraph1: "Rydych wedi gwrthod cwcis ychwanegol. Gallwch "
-        paragraph2: " unrhyw bryd."
-      changeCookiePreferencesLink: "newid eich gosodiadau cwcis"
-    cookieText: "Mae GOV.UK yn defnyddio cwcis i wneud y safle'n symlach."
-    cookieLink: "#"
-    cookieLinkText: "Darganfyddwch fwy am gwcis"
-  phaseBanner:
-    tag: "beta"
-    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i''w wella.'
+        paragraph1: Rydych wedi gwrthod cwcis ychwanegol. Gallwch
+        paragraph2: unrhyw bryd.
+      buttonAcceptText: Derbyn cwcis dadansoddi
+      buttonRejectText: Gwrthod cwcis dadansoddi
+      linkViewCookiesText: Gweld cwcis
+      cookieBannerHideLink: Cuddio'r neges yma
   footerNavItems:
     meta:
       items:
@@ -48,12 +49,32 @@ govuk:
     text: "© Hawlfraint y goron"
   contentLicence:
     html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="licence">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
+
+fraud:
+  serviceNameRequired: true
+
 error:
-  unrecoverable:
-    title: "Mae'n ddrwg gennym, mae problem"
-    subTitle: "Ni allwn brofi pwy ydych chi ar hyn o bryd."
-    subHeading: "Beth allwch chi ei wneud"
-    description: "Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
-    contactMeLink: "Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)"
-    buttonText: "Ewch i hafan GOV.UK"
-    buttonLink: "https://www.gov.uk/"
+  title: Mae'n ddrwg gennym, mae problem
+  serviceNameRequired: false
+  content:
+    - Ni allwn brofi pwy ydych chi ar hyn o bryd.
+    - <h2 class="govuk-heading-m"> Beth allwch chi ei wneud </h2>
+    - Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Ewch i hafan GOV.UK </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+
+pageNotFound:
+  title: Tudalen heb ei darganfod
+  serviceNameRequired: false
+  content:
+    - Ni allwn ddod o hyd i'r dudalen rydych chi'n chwilio amdani.
+    - <h2>Beth allwch chi ei wneud</h2>
+    - Os ydych wedi teipio'r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.
+    - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.
+    - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+
+sessionEnded:
+  title: Sesiwn wedi dod i ben
+  serviceNameRequired: false

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -9,7 +9,29 @@ check:
       - Byddwn yn gwirio'ch manylion gyda <a href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services" class="govuk-link" rel="noreferrer noopener" target="_blank">Experian (agor mewn tab newydd)</a>. Mae hyn oherwydd bod gan gwmnïau fel Experian fynediad at wybodaeth am ryngweithiadau rydych wedi'u cael yn y gorffennol gyda sefydliadau eraill.
       - <p><a href="https://signin.account.gov.uk/privacy-notice" class="govuk-link" rel="noreferrer noopener" target="_blank">Darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a> os hoffech wybod mwy am sut bydd eich manylion yn cael eu defnyddio i brofi pwy ydych chi.</p>
 error:
-  unrecoverable:
-    title: "Mae'n ddrwg gennym, mae problem"
+  title: Mae'n ddrwg gennym, mae problem
+  serviceNameRequired: false
+  content:
+    - Ni allwn brofi pwy ydych chi ar hyn o bryd.
+    - <h2 class="govuk-heading-m"> Beth allwch chi ei wneud </h2>
+    - Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Ewch i hafan GOV.UK </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+
+pageNotFound:
+  title: Tudalen heb ei darganfod
+  serviceNameRequired: false
+  content:
+    - Ni allwn ddod o hyd i'r dudalen rydych chi'n chwilio amdani.
+    - <h2>Beth allwch chi ei wneud</h2>
+    - Os ydych wedi teipio'r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.
+    - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.
+    - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
+
+sessionEnded:
+  title: Sesiwn wedi dod i ben
+  serviceNameRequired: false
 
 

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -2,59 +2,79 @@ buttons:
   next: Continue
   cancel: Cancel
 govuk:
+  phaseBanner:
+    tag: beta
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   serviceName: Prove your identity
   backLink: Back
   errorSummaryTitle: There's a problem
   error: Error
   warning: Warning
   skipLink: Skip to main content
+  betaBannerRequired: true
+  betaBannerContent:
+    betaBannerContentLabel: beta
+    betaBannerContentHTML: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">feedback (opens in new tab)</a>  will help us to improve it.'
   cookie:
     cookieBanner:
-      title: "Cookies on GOV.UK One Login"
-      heading: "Cookies on GOV.UK One Login"
-      paragraph1: "We use some essential cookies to make this service work."
-      paragraph2: "We'd also like to use analytics cookies so we can understand how you use the service and make improvements."
-      buttonAcceptText: "Accept analytics cookies"
-      buttonRejectText: "Reject analytics cookies"
-      linkViewCookiesText: "View cookies"
-      cookieBannerHideLink: "Hide this message"
+      title: Cookies on GOV.UK One Login
+      heading: Cookies on GOV.UK One Login
+      paragraph1: We use some essential cookies to make this service work.
+      paragraph2: We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.
+      changeCookiePreferencesLink: change your cookie settings
       cookieBannerAccept:
         paragraph1: "You've accepted additional cookies. You can "
         paragraph2: " at any time."
       cookieBannerReject:
         paragraph1: "You've rejected additional cookies. You can "
         paragraph2: " at any time."
-      changeCookiePreferencesLink: "change your cookie settings"
-    cookieText: "GOV.UK uses cookies to make the site simpler."
-    cookieLink: "#"
-    cookieLinkText: "Find out more about cookies"
-  phaseBanner:
-    tag: beta
-    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+      buttonAcceptText: Accept analytics cookies
+      buttonRejectText: Reject analytics cookies
+      linkViewCookiesText: View cookies
+      cookieBannerHideLink: Hide this message
   footerNavItems:
     meta:
       items:
-        - href: https://signin.account.gov.uk/accessibility-statement
-          text: Accessibility statement
-        - href: https://signin.account.gov.uk/cookies
-          text: Cookies
-        - href: https://signin.account.gov.uk/terms-and-conditions
-          text: Terms and conditions
-        - href: https://signin.account.gov.uk/privacy-notice
-          text: Privacy notice
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login
-          text: Support
+        - href: "https://signin.account.gov.uk/accessibility-statement"
+          text: "Accessibility statement"
+        - href: "https://signin.account.gov.uk/cookies"
+          text: "Cookies"
+        - href: "https://signin.account.gov.uk/terms-and-conditions"
+          text: "Terms and conditions"
+        - href: "https://signin.account.gov.uk/privacy-notice"
+          text: "Privacy notice"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
+          text: "Support"
   copyright:
     text: "© Crown copyright"
   contentLicence:
     html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Open Government Licence v3.0</a>, except where otherwise stated'
 
+fraud:
+  serviceNameRequired: true
+
 error:
-  unrecoverable:
-    title: Sorry, there is a problem with the service
-    subTitle: We cannot prove your identity right now.
-    subHeading: What can you do
-    description: Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
-    contactMeLink: Contact the GOV.UK One Login team (opens in a new tab)
-    buttonText: Go to the GOV.UK homepage
-    buttonLink: https://www.gov.uk/
+  title: Sorry, there is a problem
+  serviceNameRequired: false
+  content:
+    - We cannot prove your identity right now.
+    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
+
+pageNotFound:
+  title: Page not found
+  serviceNameRequired: false
+  content:
+    - We cannot find the page you're looking for.
+    - <h2>What you can do</h2>
+    - If you typed the web address, check it’s correct.
+    - If you pasted the web address, check you copied the entire address.
+    - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
+
+sessionEnded:
+  title: Session expired
+  serviceNameRequired: false

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -9,5 +9,27 @@ check:
     - We'll check your details with <a href="https://www.experian.co.uk/privacy/privacy-and-your-data?utm_medium=internalRef&utm_source=Consumer%20Services" class="govuk-link" rel="noreferrer noopener" target="_blank">Experian (opens in new tab)</a>. This is because companies like Experian have access to information about interactions you've previously had with other organisations.
     - <p><a href="https://signin.account.gov.uk/privacy-notice" class="govuk-link" rel="noreferrer noopener" target="_blank">Read our privacy notice (opens in new tab)</a> if you'd like to know more about how your details will be used to prove your identity.</p>
 error:
-  unrecoverable:
-    title: Sorry, there is a problem with the service
+  title: Sorry, there is a problem
+  serviceNameRequired: false
+  content:
+    - We cannot prove your identity right now.
+    - <h2 class="govuk-heading-m"> What you can do </h2>
+    - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
+
+pageNotFound:
+  title: Page not found
+  serviceNameRequired: false
+  content:
+    - We cannot find the page you're looking for.
+    - <h2>What you can do</h2>
+    - If you typed the web address, check it’s correct.
+    - If you pasted the web address, check you copied the entire address.
+    - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
+    - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
+
+sessionEnded:
+  title: Session expired
+  serviceNameRequired: false

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,3 +1,11 @@
-<!-- Found in common folder -->
-{% set gtmJourney = "fraud - error" %}
-{% extends "unrecoverable-error.njk" %}
+{% extends "base-page.njk" %}
+{% set hmpoPageKey = "error" %}
+
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+    {{ translate("error.title") }}
+</h1>
+
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+{{ hmpoHtml(translate("error.content")) }}
+{% endblock %}

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -1,3 +1,12 @@
 {% extends "base-page.njk" %}
-{% set hmpoPageKey = "errors.pageNotFound" %}
-{% set gtmJourney = "fraud - error" %}
+{% set hmpoPageKey = "pageNotFound" %}
+
+
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+    {{ translate("pageNotFound.title") }}
+</h1>
+
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+{{ hmpoHtml(translate("pageNotFound.content")) }}
+{% endblock %}

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -1,3 +1,12 @@
 {% extends "base-page.njk" %}
-{% set hmpoPageKey = "errors.sessionEnded" %}
-{% set gtmJourney = "fraud - error" %}
+{% set hmpoPageKey = "sessionEnded" %}
+
+{% block mainContent %}
+<h1 id="header" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+    {{ translate("sessionEnded.title") }}
+</h1>
+
+{% from "hmpo-html/macro.njk" import hmpoHtml %}
+{{ hmpoHtml(translate("sessionEnded.content")) }}
+
+{% endblock %}

--- a/test/browser/pages/error.js
+++ b/test/browser/pages/error.js
@@ -7,11 +7,11 @@ module.exports = class PlaywrightDevPage {
   }
 
   getSomethingWentWrongMessage() {
-    return "Sorry, there is a problem with the service";
+    return "Sorry, there is a problem – Prove your identity – GOV.UK";
   }
 
   getErrorTitle() {
-    return this.page.textContent('[data-id="error-title"]');
+    return this.page.title();
   }
 
   isCurrentPage() {


### PR DESCRIPTION
## Proposed changes

### What changed

Updated Fraud CRI to align with other LIME CRIs
Added custom error pages to overwrite common express
Updated locales files

### Why did it change

To align with the other LIME CRIs
and to ensure error page content could be updated

