### PR TITLE
LIME-868: Setting log level to warn by default and debug for dev runs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -47,6 +47,13 @@ Mappings:
   ElasticLoadBalancerAccountIds:
     eu-west-2:
       AccountId: 652711504416
+  LogLevel:
+    Environment:
+      dev: "debug"
+      build: "debug"
+      staging: "request"
+      integration: "request"
+      production: "request"
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -372,6 +379,8 @@ Resources:
               Value: !If [IsProduction, "GTM-TT5HDKV", "GTM-TK92W68"]
             - Name: ANALYTICS_DOMAIN
               Value: !If [IsProduction, "account.gov.uk", !Sub "${Environment}.account.gov.uk"]
+            - Name: LOG_LEVEL
+              Value: !FindInMap [LogLevel, Environment, !Ref 'Environment']
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/app.js",
     "start:ci": "API_BASE_URL=http://127.0.0.1:8030 REDIS_SESSION_URL= NODE_ENV=development node src/app.js",
-    "dev": "nodemon src/app.js",
+    "dev": "LOG_LEVEL=debug nodemon src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts && copyfiles -u 3 src/assets/images/* dist/public/images",

--- a/src/app.js
+++ b/src/app.js
@@ -23,11 +23,13 @@ const {
   SESSION_SECRET,
   SESSION_TABLE_NAME,
   SESSION_TTL,
+  LOG_LEVEL,
 } = require("./lib/config");
 
 const { setup } = require("hmpo-app");
 
 const loggerConfig = {
+  consoleLevel: LOG_LEVEL,
   console: true,
   consoleJSON: true,
   app: false,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -20,6 +20,7 @@ module.exports = {
     },
   },
   PORT: process.env.PORT || 5030,
+  LOG_LEVEL: process.env.LOG_LEVEL || "request",
   SESSION_SECRET: process.env.SESSION_SECRET,
   SESSION_TABLE_NAME: process.env.SESSION_TABLE_NAME,
   SESSION_TTL: process.env.SESSION_TTL || 7200000, // two hours in ms


### PR DESCRIPTION
## Proposed changes

### What changed

Added config to set the log level to warn and debug in the lower environments

### Why did it change

To ensure log levels are always correctly set in the higher environments for hmpo-app and common express

