### PR TITLE
LIME-1020 Update common-express to 5.0.0.0 and govuk-frontend 4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,12 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.6",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "govuk-one-login/ipv-cri-common-express.git#v4.0.0",
+    "di-ipv-cri-common-express": "govuk-one-login/ipv-cri-common-express.git#v5.0.0.0",
     "dotenv": "16.0.2",
     "express": "4.18.2",
     "express-async-errors": "3.1.1",
     "express-session": "^1.17.3",
-    "govuk-frontend": "4.4.1",
+    "govuk-frontend": "4.8.0",
     "hmpo-app": "2.4.0",
     "hmpo-components": "6.3.0",
     "hmpo-config": "3.0.0",
@@ -85,7 +85,7 @@
     "hmpo-i18n": "5.0.2",
     "hmpo-logger": "7.0.1",
     "jsonwebtoken": "9.0.0",
-    "nunjucks": "3.2.3"
+    "nunjucks": "3.2.4"
   },
   "resolutions": {
     "strip-ansi": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,9 +1617,9 @@ destroy@1.2.0:
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-di-ipv-cri-common-express@govuk-one-login/ipv-cri-common-express.git#v4.0.0:
-  version "4.0.0-0"
-  resolved "https://codeload.github.com/govuk-one-login/ipv-cri-common-express/tar.gz/cf1e52582111519559e5ab6fc41f8c44309e7db9"
+di-ipv-cri-common-express@govuk-one-login/ipv-cri-common-express.git#v5.0.0.0:
+  version "5.0.0"
+  resolved "https://codeload.github.com/govuk-one-login/ipv-cri-common-express/tar.gz/5260c9defa2e29f42efec4c3dff54be505e7c824"
   dependencies:
     hmpo-logger "7.0.1"
     i18next "23.6.0"
@@ -2483,10 +2483,10 @@ got@<12:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz"
-  integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
+govuk-frontend@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
+  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.8"
@@ -3795,10 +3795,10 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-nunjucks@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz"
-  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
+nunjucks@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
+  integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==
   dependencies:
     a-sync-waterfall "^1.0.0"
     asap "^2.0.3"


### PR DESCRIPTION
## Proposed changes

### What changed

Update common-express to 5.0.0.0 and govuk-frontend 4.8.0

- note useTudorCrown=true feature toggle no effect until common-express 5.1.0

### Why did it change

Preparatory step to switch over to the GOV.UK logo

### Issue tracking

- [LIME-1020](https://govukverify.atlassian.net/browse/LIME-1020)


[LIME-1020]: https://govukverify.atlassian.net/browse/LIME-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ