### PR TITLE
LIME-1014 Switch to common-express NPM package and update to version 5.0.0, govuk-frontend updated to 4.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "di-ipv-cri-fraud-front",
   "version": "0.0.1",
   "description": "User interface for the Identity Proofing and Verification (IPV) system within the GDS digital identity platform, GOV.UK Sign In.",
-  "main": "src/server.js",
+  "main": "src/app.js",
   "engines": {
     "node": "20.*",
     "yarn": "1.22.*"
@@ -15,8 +15,8 @@
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist/public/scripts && mkdir -p dist/public/images && mkdir -p dist/locales && cp -R src/locales/* dist/locales && cp -R src/assets/javascripts/*.js dist/public/scripts && cp -R src/assets/images/* dist/public/images",
     "build-js": "yarn build-js:application && yarn build-js:analytics && yarn build-js:all",
-    "build-js:application": "mkdir -p dist/public/javascripts; uglifyjs src/assets/javascripts/application.js  node_modules/di-ipv-cri-common-express/src/assets/javascript/application.js --beautify -o dist/public/javascripts/application.js",
-    "build-js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/di-ipv-cri-common-express/src/assets/javascript/analytics/**/*.js node_modules/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/legacy/cookies.js node_modules/di-ipv-cri-common-express/src/assets/javascript/analytics/*.js --beautify -o dist/public/javascripts/analytics.js",
+    "build-js:application": "mkdir -p dist/public/javascripts; uglifyjs src/assets/javascripts/application.js  node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/application.js --beautify -o dist/public/javascripts/application.js",
+    "build-js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/**/*.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/legacy/cookies.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/*.js --beautify -o dist/public/javascripts/analytics.js",
     "build-js:all": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js node_modules/hmpo-components/all.js --beautify -o dist/public/javascripts/all.js",
     "minfiy-build-js": "uglifyjs src/assets/javascript/application.js -o src/assets/javascript/application.js -c -m && uglifyjs src/assets/javascript/cookies.js -o src/assets/javascript/cookies.js -c -m",
     "lint": "prettier --check --no-editorconfig src test && eslint .",
@@ -28,7 +28,7 @@
     "mocks": "yarn run wiremock --port 8030 --root-dir test/mocks",
     "test:browser": "mkdir -p reports && wait-on tcp:127.0.0.1:8030 tcp:127.0.0.1:5030 && API_BASE_URL=http://127.0.0.1:8030 MOCK_API=true cucumber-js --config test/browser/cucumber.js",
     "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
-    "check-translation": "node node_modules/di-ipv-cri-common-express/scripts/checkTranslations.js"
+    "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "repository": {
     "type": "git",
@@ -72,12 +72,12 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.6",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "govuk-one-login/ipv-cri-common-express.git#v4.0.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "5.0.0",
     "dotenv": "16.0.2",
     "express": "4.18.2",
     "express-async-errors": "3.1.1",
     "express-session": "^1.17.3",
-    "govuk-frontend": "4.4.1",
+    "govuk-frontend": "4.7.0",
     "hmpo-app": "2.4.0",
     "hmpo-components": "6.3.0",
     "hmpo-config": "3.0.0",
@@ -85,7 +85,7 @@
     "hmpo-i18n": "5.0.2",
     "hmpo-logger": "7.0.1",
     "jsonwebtoken": "9.0.0",
-    "nunjucks": "3.2.3"
+    "nunjucks": "3.2.4"
   },
   "resolutions": {
     "strip-ansi": "^6.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -7,15 +7,19 @@ const AWS = require("aws-sdk");
 const DynamoDBStore = require("connect-dynamodb")(session);
 const featureSets = require("./app/fraud/featureSets");
 
-const commonExpress = require("di-ipv-cri-common-express");
+const commonExpress = require("@govuk-one-login/di-ipv-cri-common-express");
 
 const setHeaders = commonExpress.lib.headers;
 const setScenarioHeaders = commonExpress.lib.scenarioHeaders;
 const setAxiosDefaults = commonExpress.lib.axios;
 
 const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
-const { setGTM } = require("di-ipv-cri-common-express/src/lib/settings");
-const { getGTM } = require("di-ipv-cri-common-express/src/lib/locals");
+const {
+  setGTM
+} = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/settings");
+const {
+  getGTM
+} = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/locals");
 
 const {
   API,
@@ -53,7 +57,7 @@ const sessionConfig = {
   ...(SESSION_TABLE_NAME && { sessionStore: dynamoDBSessionStore })
 };
 
-const helmetConfig = require("di-ipv-cri-common-express/src/lib/helmet");
+const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
@@ -75,7 +79,9 @@ const { app, router } = setup({
   },
   views: [
     path.resolve(
-      path.dirname(require.resolve("di-ipv-cri-common-express")),
+      path.dirname(
+        require.resolve("@govuk-one-login/di-ipv-cri-common-express")
+      ),
       "components"
     ),
     "views"

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,9 +180,9 @@
   integrity sha512-+Ce7T5iPNWzfu9C1aB5tN3Lyafs5xb3Ic7vBWyZL2KXT3QSdD1dD3CvgOzPmQKoNNRt6uauc0XwNJTQtXC2/Mw==
 
 "@babel/runtime@^7.22.5":
-  version "7.23.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
-  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  version "7.23.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
+  integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -382,6 +382,18 @@
   version "8.53.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.53.0.tgz#bea56f2ed2b5baea164348ff4d5a879f6f81f20d"
   integrity sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==
+
+"@govuk-one-login/di-ipv-cri-common-express@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-5.0.0.tgz#7c2ecf3061b26e7ca4debc860e4a0bb5929741a9"
+  integrity sha512-OYfU6g4TQ374wGIDIEMDhe1z9Y60nbMvTsuRxQRtqdr0uxOqLuwuBEXZopbe6DFctHwzU2IS+Fgmgl8i5WJRxA==
+  dependencies:
+    hmpo-logger "7.0.1"
+    i18next "23.6.0"
+    i18next-fs-backend "2.2.0"
+    i18next-http-middleware "3.4.1"
+    lodash.differencewith "4.5.0"
+    lodash.frompairs "4.0.1"
 
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
@@ -1617,17 +1629,6 @@ destroy@1.2.0:
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-di-ipv-cri-common-express@govuk-one-login/ipv-cri-common-express.git#v4.0.0:
-  version "4.0.0-0"
-  resolved "https://codeload.github.com/govuk-one-login/ipv-cri-common-express/tar.gz/cf1e52582111519559e5ab6fc41f8c44309e7db9"
-  dependencies:
-    hmpo-logger "7.0.1"
-    i18next "23.6.0"
-    i18next-fs-backend "2.2.0"
-    i18next-http-middleware "3.4.1"
-    lodash.differencewith "4.5.0"
-    lodash.frompairs "4.0.1"
-
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
@@ -2483,10 +2484,10 @@ got@<12:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz"
-  integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
+govuk-frontend@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
+  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.8"
@@ -3795,10 +3796,10 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-nunjucks@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz"
-  integrity sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==
+nunjucks@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/nunjucks/-/nunjucks-3.2.4.tgz#f0878eef528ce7b0aa35d67cc6898635fd74649e"
+  integrity sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==
   dependencies:
     a-sync-waterfall "^1.0.0"
     asap "^2.0.3"


### PR DESCRIPTION
## Proposed changes

### What changed

Switch to the @govuk-one-login/di-ipv-cri-common-express NPM package 

common-express updated to version 5.0.0, 

govuk-frontend updated to 4.7.0

### Why did it change

Git releases are being deprecated in favor of the NPM releases

common-express updated to prepare for 5.x release

govuk-frontend update in preparation of switch to 4.8 release

### Issue tracking

- [LIME-1014](https://govukverify.atlassian.net/browse/LIME-1014)


[LIME-1014]: https://govukverify.atlassian.net/browse/LIME-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ