### PR TITLE
LIME-921 - Removing crosscore Version featureSet

### DIFF
--- a/src/app/fraud/controllers/check.js
+++ b/src/app/fraud/controllers/check.js
@@ -13,10 +13,6 @@ class FraudCheckController extends BaseController {
       session_id: req.session.tokenId
     };
 
-    if (req.session.featureSet === "crosscoreV2") {
-      headers["crosscore-version"] = "2";
-    }
-
     const fraudCheck = await req.axios.post(
       `${CHECK}`,
       {},

--- a/src/app/fraud/controllers/check.test.js
+++ b/src/app/fraud/controllers/check.test.js
@@ -59,44 +59,4 @@ describe("check controller", () => {
 
     expect(req.sessionModel.get("redirect_url")).to.eq(data.redirectUrl);
   });
-
-  it("should add a crosscore version header if a feature set has been set", async () => {
-    const sessionId = "fraud123";
-
-    req.session.tokenId = sessionId;
-    req.session.authParams = {
-      redirect_uri: "https://client.example.com",
-      state: "A VALUE"
-    };
-
-    req.session.authParams = {
-      redirect_uri: "https://client.example.com",
-      state: "A VALUE"
-    };
-    req.session.featureSet = "crosscoreV2";
-
-    const data = {
-      authorization_code: "1234"
-    };
-
-    const resolvedPromise = new Promise((resolve) => resolve({ data }));
-    let stub = sandbox.stub(req.axios, "post").returns(resolvedPromise);
-
-    await check.saveValues(req, res, next);
-
-    sandbox.assert.calledWith(
-      stub,
-      "identity-check",
-      {},
-      {
-        headers: {
-          "Content-Type": "application/application-json",
-          "crosscore-version": "2",
-          session_id: sessionId
-        }
-      }
-    );
-
-    expect(req.session.authParams.authorization_code).to.eq("1234");
-  });
 });


### PR DESCRIPTION
### What changed
Removing logic for featureSetting crosscore version, after this PR and the corresponding api PR are merged this will route all users to V2 -
 https://github.com/govuk-one-login/ipv-cri-fraud-api/pull/211

Additional Note:
Opted to keep featureSetting logic in despite it currently not being used as this may become a useful utility in the future

###DO NOT MERGE