### PR TITLE
DFC-529 - Revert helmet.js import change

### DIFF
--- a/src/app-setup.js
+++ b/src/app-setup.js
@@ -7,7 +7,7 @@ const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
 const sessionConfigService = require("./session-config");
 
 const path = require("path");
-const helmetConfig = commonExpress.lib.helmet;
+const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
 const setHeaders = commonExpress.lib.headers;
 
 const init = (app) => {

--- a/src/app-setup.test.js
+++ b/src/app-setup.test.js
@@ -1,6 +1,7 @@
 const AppSetup = require("./app-setup");
 const path = require("path");
 const sessionConfig = require("./session-config");
+const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
 
 describe("app-setup", () => {
   const sandbox = sinon.createSandbox();
@@ -90,7 +91,7 @@ describe("app-setup", () => {
           cookieOptions: { maxAge: 7200000 },
           ...("table-name" && { sessionStore: {} })
         },
-        helmet: undefined, // To be tested separately
+        helmet: helmetConfig,
         redis: isDynamoBool ? false : commonExpress.lib.redis(),
         urls: {
           public: "/public",

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -47,7 +47,7 @@ describe("app", () => {
         table: SESSION_TABLE_NAME
       });
 
-      const helmetConfig = commonExpress.lib.helmet;
+      const helmetConfig = require("@govuk-one-login/di-ipv-cri-common-express/src/lib/helmet");
 
       const sessionConfig = {
         cookieName: "service_session",


### PR DESCRIPTION
## Proposed changes

### What changed

The helmet.js import for common-express was modified during the GA4 implementation to match how other files were being imported, that modification has been reverted and the tests updated accordingly.

### Why did it change

The change to how helmet.js was imported resulted in the CSP errors appearing to be resolved, in reality the config was not being passed into the repository correctly. This PRs change fixes this issue.

### Issue tracking

- [DFC-529](https://govukverify.atlassian.net/browse/DFC-529)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
