### PR TITLE
IPS-556/fraud ecs canary stage 2

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -390,22 +390,29 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
         # This is an alternative implementation if you want to split across all PrivateSubnets (but don't know how many there are)
         # Fn::Split:
         #   [ ",", Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnets" ]
-      TaskDefinition: !Ref ECSServiceTaskDefinition
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"


### PR DESCRIPTION
## Proposed changes

### What changed
Stage 2 of 2 for enabling ECS Canaries (Stage 1 is [here](https://github.com/govuk-one-login/ipv-cri-fraud-front/pull/475))

This is a fairly arbitrary change to trigger the deployment process, but removes some now-unused ECS config.

### Why did it change
Canary deployments provide extra safety measures when rolling out new application image versions

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-556

AllAtOnce rollout tested in `-dev`:
![Screenshot 2024-08-12 at 15 04 49](https://github.com/user-attachments/assets/2c2c5ee1-99b5-4033-b49e-d13ae4a78e6f)
![Screenshot 2024-08-12 at 15 08 18](https://github.com/user-attachments/assets/e0e837cf-5eab-4663-afba-facea07adb13)
