### PR TITLE
IPS-1132: Add linting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
+      - name: SAM Validate
+        run: sam validate --region eu-west-2 -t deploy/template.yaml --lint
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       # Likely source of node warning
       # https://github.com/aws-actions/amazon-ecr-login/issues/586

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-json
       - id: end-of-file-fixer
@@ -10,13 +10,13 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.61.0 # The version of cfn-lint to use
+    rev: v1.15.2 # The version of cfn-lint to use
     hooks:
       - id: cfn-python-lint
         files: .template\.yaml$
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: "2.0.1211"
+    rev: "3.2.256"
     hooks:
       - id: checkov
         verbose: true

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -388,7 +388,10 @@ Resources:
         - !Ref "Environment"
         - desiredTaskCount
       EnableECSManagedTags: false
-      HealthCheckGracePeriodSeconds: 60
+      HealthCheckGracePeriodSeconds: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - 60
       LaunchType: FARGATE
       LoadBalancers: !If
         - UseCanaryDeployment


### PR DESCRIPTION
### What changed
- Add SAM validate on pre-merge checks and lint on the pre and post merge checks
- Ran `pre-commit autoupdate`

The following change was required to pass the new linting steps:

1. Create condition for `HealthCheckGracePeriodSeconds` (this Property is only used if canaries are disabled ie if the service is using a load balancer and not managed by CodeDeploy). This was to fix `E3056 | ECS service using HealthCheckGracePeriodSeconds must also have LoadBalancers specified` [E3056](https://github.com/aws-cloudformation/cfn-lint/blob/main/src/cfnlint/rules/resources/ecs/ServiceHealthCheckGracePeriodSeconds.py) See the docs at:
  - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html
  - https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance

### Why did it change

- Code quality control

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [IPS-1132](https://govukverify.atlassian.net/browse/IPS-1132)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[IPS-1132]: https://govukverify.atlassian.net/browse/IPS-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ