### PR TITLE
LIME-1382 govuk-frontend dependency updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "express": "4.18.2",
     "express-async-errors": "3.1.1",
     "express-session": "^1.17.3",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "4.9.0",
     "hmpo-app": "2.4.0",
     "hmpo-components": "6.3.0",
     "hmpo-config": "3.0.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

govuk-frontend dependency version updated from 4.8.0 to 4.9.0, which updates crown copyright logo, ready for go live on Dec 2nd 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1382](https://govukverify.atlassian.net/browse/LIME-1382

Old crown copyright logo:
<img width="238" alt="Screenshot 2024-11-21 at 09 47 25" src="https://github.com/user-attachments/assets/b446ed3b-bd03-4970-b237-82b7454a6d7e">

New crown copyright logo:
<img width="1728" alt="Screenshot 2024-11-21 at 09 16 16" src="https://github.com/user-attachments/assets/6fc7e82b-64cf-4f3c-ba9d-0883900a4e1d">


### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1382]: https://govukverify.atlassian.net/browse/LIME-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ