### PR TITLE
LIME-1480 hmpo-components updated to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "express-session": "^1.17.3",
     "govuk-frontend": "4.9.0",
     "hmpo-app": "2.4.0",
-    "hmpo-components": "6.3.0",
+    "hmpo-components": "7.1.0",
     "hmpo-config": "3.0.0",
     "hmpo-form-wizard": "12.0.6",
     "hmpo-i18n": "5.0.2",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

hmpo-components updated to v7.1.0. This was previously a breaking update in passport and DL FEs due to a .prefix box appearing in every input field in the browser. Fraud does not have any input fields however checks have been completed to confirm this update will not cause any other issues. 
### Why did it change

To facilitate update to v7.1.0

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1480](https://govukverify.atlassian.net/browse/LIME-1480)

### Other considerations

Same update and workarounds being implemented in Passport and DL FEs.


Evidence on ticket

[LIME-1480]: https://govukverify.atlassian.net/browse/LIME-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ