### PR TITLE
IPS-1284: Predictive scaling for ECS in forecast mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: end-of-file-fixer

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -281,40 +281,37 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 63
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 103
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 578
-        "line_number": 578
+        "line_number": 588
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 579
-        "line_number": 579
+        "line_number": 589
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 581
-        "line_number": 581
+        "line_number": 591
       }
     ]
   },
-  "generated_at": "2025-01-07T11:57:22Z"
+  "generated_at": "2025-01-16T12:08:44Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -281,20 +281,21 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 60
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
+        "line_number": 578
         "line_number": 578
       },
       {
@@ -303,6 +304,7 @@
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
         "line_number": 579
+        "line_number": 579
       },
       {
         "type": "Secret Keyword",
@@ -310,8 +312,9 @@
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
         "line_number": 581
+        "line_number": 581
       }
     ]
   },
-  "generated_at": "2025-01-06T11:56:55Z"
+  "generated_at": "2025-01-07T11:57:22Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -46,9 +46,6 @@ Conditions:
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
   IsProduction: !Equals [!Ref Environment, production]
-  IsPerformance: !Or
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, production]
   UsePermissionsBoundary: !Not
     - !Equals [!Ref PermissionsBoundary, "none"]
   UseCodeSigning: !Not
@@ -66,6 +63,8 @@ Mappings:
       ga4Enabled: "true"
       uaEnabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 1
+      maxECSCount: 4
     build:
       logLevel: "info"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -74,6 +73,8 @@ Mappings:
       ga4Enabled: "true"
       uaEnabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 4
+      maxECSCount: 60
     staging:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -82,6 +83,8 @@ Mappings:
       ga4Enabled: "true"
       uaEnabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -90,6 +93,8 @@ Mappings:
       ga4Enabled: "true"
       uaEnabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 2
+      maxECSCount: 4
     production:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -98,6 +103,8 @@ Mappings:
       ga4Enabled: "true"
       uaEnabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 4
+      maxECSCount: 60
 
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -750,22 +757,36 @@ Resources:
 
   # ECS Autoscaling
   ECSAutoScalingTarget:
-    Condition: IsPerformance
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MinCapacity: 4
-      MaxCapacity: 60
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref FraudFrontEcsCluster
-          - !GetAtt FraudFrontEcsService.Name
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+      ResourceId: !Sub service/${FraudFrontEcsCluster}/${FraudFrontEcsService.Name}
       RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
+  ECSPredictiveScalingPolicy:
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSPredictiveScalingPolicy
+      PolicyType: PredictiveScaling
+      ResourceId: !Sub service/${FraudFrontEcsCluster}/${FraudFrontEcsService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      PredictiveScalingPolicyConfiguration:
+        MaxCapacityBreachBehavior: HonorMaxCapacity
+        MetricSpecifications:
+          - PredefinedMetricPairSpecification:
+              PredefinedMetricType: ECSServiceCPUUtilization
+            TargetValue: 60
+        Mode: ForecastOnly
+        SchedulingBufferTime: 600
+
   EcsStepScaleOutPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -807,7 +828,6 @@ Resources:
             # on Fargate, so leave the upper bound open
 
   EcsStepScaleInPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -839,7 +859,6 @@ Resources:
             # with <20% utilisation
 
   EcsStepScaleOutAlarm:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -863,7 +882,6 @@ Resources:
       Threshold: "60"
 
   EcsStepScaleInAlarm:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -46,6 +46,9 @@ Conditions:
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
   IsProduction: !Equals [!Ref Environment, production]
+  # IsPerformance: !Or
+  # - !Equals [!Ref Environment, build]
+  # - !Equals [!Ref Environment, production]
   UsePermissionsBoundary: !Not
     - !Equals [!Ref PermissionsBoundary, "none"]
   UseCodeSigning: !Not
@@ -933,10 +936,10 @@ Resources:
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
 
-  FraudOnlyOneTaskCountAlarm:
+  FraudBelowMinTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Fraud ${Environment} frontend below desired ECS service tasks
+      AlarmDescription: !Sub Fraud ${Environment} frontend below minimum ECS service tasks
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicFraud
@@ -952,7 +955,7 @@ Resources:
       Period: 300
       EvaluationPeriods: 3
       DatapointsToAlarm: 3
-      Threshold: 2
+      Threshold: !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
 


### PR DESCRIPTION
### What changed

- Added capacity mapping for ECS task counts 
- Removed condition on creating auto scaling policy so it applies to all envs
- This adds a new Predicitive scaling policy which will scale the number of instances based on some AWS created  algorithm using the previous traffic patterns as input. See this for more information:
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html
- The policy is in `Forecast Mode` only so we can understand its behaviour. The predictive scaling policy will not take any action
<img width="500" alt="image" src="https://github.com/user-attachments/assets/adf7f5eb-0e65-4482-8109-acba3c295bcf" />

- Update min task alarm to a lower use mapping to prevent noise in dev:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/30339f3b-a158-413f-8784-73b91dc7942b" />

### Why did it change

- Cost saving
- To be more Environmentally friendly
- Reliability for users

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1284