### PR TITLE
LIME-1514: Added Axe Accessibility Script to run on page load

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.15.2 # The version of cfn-lint to use
+    rev: v1.22.5 # The version of cfn-lint to use
     hooks:
       - id: cfn-python-lint
         files: .template\.yaml$
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: "3.2.256"
+    rev: "3.2.353"
     hooks:
       - id: checkov
         verbose: true

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,8 @@ export default [
         ...globals.browser,
         sinon: true,
         expect: true,
-        setupDefaultMocks: true
+        setupDefaultMocks: true,
+        axe: true
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.1.1",
+    "axe-playwright": "^2.0.3",
     "axios": "1.7.7",
     "cfenv": "1.2.4",
     "chai-http": "^5.1.1",

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -4,10 +4,19 @@ const { expect } = require("chai");
 
 const { ErrorPage } = require("../pages");
 
+const { injectAxe } = require("axe-playwright");
+
 Then("they should see an error page", async function () {
   const errorPage = new ErrorPage(this.page);
 
   const errorTitle = await errorPage.getErrorTitle();
-
+  await injectAxe(this.page);
+  // Run Axe for WCAG 2.2 AA rules
+  const wcagResults = await this.page.evaluate(() => {
+    return axe.run({
+      runOnly: ["wcag2aa"]
+    });
+  });
+  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   expect(errorTitle).to.equal(errorPage.getSomethingWentWrongMessage());
 });

--- a/test/browser/step_definitions/fraud.js
+++ b/test/browser/step_definitions/fraud.js
@@ -4,11 +4,20 @@ const { expect } = require("chai");
 
 const { CheckPage } = require("../pages");
 
+const { injectAxe } = require("axe-playwright");
+
 When(/^they (?:have )?start(?:ed)? the Fraud journey$/, async function () {});
 
 Given(/they (?:can )?see? the check page$/, async function () {
   const checkPage = new CheckPage(this.page);
-
+  await injectAxe(this.page);
+  // Run Axe for WCAG 2.2 AA rules
+  const wcagResults = await this.page.evaluate(() => {
+    return axe.run({
+      runOnly: ["wcag2aa"]
+    });
+  });
+  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   expect(checkPage.isCurrentPage()).to.be.true;
 });
 

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -13,7 +13,7 @@ BeforeAll(async function () {
   } else {
     global.browser = await chromium.launch({
       // Not headless so we can watch test runs
-      headless: false,
+      headless: true,
       // Slow so we can see things happening
       slowMo: 500
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,6 +2015,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/junit-report-builder@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz#17cc131d14ceff59dcf14e5847bd971b96f2cbe0"
+  integrity sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==
+
 "@types/keyv@*":
   version "3.1.4"
   resolved "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz"
@@ -2295,6 +2300,29 @@ aws-sdk@^2.814.0:
     util "^0.12.4"
     uuid "8.0.0"
     xml2js "0.6.2"
+
+axe-core@^4.10.0:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
+  integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
+axe-html-reporter@2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz#749a4d5836f6aebb6780049933c2f6030e06c7d0"
+  integrity sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==
+  dependencies:
+    mustache "^4.0.1"
+
+axe-playwright@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/axe-playwright/-/axe-playwright-2.0.3.tgz#a7b1250f22f237ee0f38974722fa695dfd641b31"
+  integrity sha512-s7iI2okyHHsD3XZK4RMJtTy2UASkNWLQtnzLuaHiK3AWkERf+cqZJqkxb7O4b56fnbib9YnZVRByTl92ME3o6g==
+  dependencies:
+    "@types/junit-report-builder" "^3.0.2"
+    axe-core "^4.10.0"
+    axe-html-reporter "2.2.11"
+    junit-report-builder "^5.1.1"
+    picocolors "^1.1.0"
 
 axios@1.7.7:
   version "1.7.7"
@@ -3814,6 +3842,11 @@ fsevents@2.3.2, fsevents@~2.3.2:
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -4035,10 +4068,10 @@ got@<12:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz"
-  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
+govuk-frontend@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.9.0.tgz#a09068130fa087e67de25956940cb8280a364372"
+  integrity sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.8"
@@ -4157,17 +4190,17 @@ hmpo-app@2.4.0:
     underscore "^1.13.4"
     uuid "^8.3.2"
 
-hmpo-components@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/hmpo-components/-/hmpo-components-6.3.0.tgz#f32c36f591149738a8db50fef3ed3416a0ccfbe2"
-  integrity sha512-0PVDp6lgYtJM/heul56qkWHTgLh0Xz5cClrFQ+09QU2t5YEsTIOqwwkksIChP6/af8TJAGkXuKyJY/vOya3cEg==
+hmpo-components@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/hmpo-components/-/hmpo-components-7.1.0.tgz#bae09ce82d3bb6a0a35d3f1d243f46dd7ae2ade0"
+  integrity sha512-gv/m2+tDfHU10xxnT9seoI2nVtJEgcMSFfl3zACdUY1rNV3SCUv426tvxuq0Z/7jAoHLfB8mvDcHaHpPEysVLw==
   dependencies:
     bytes "^3.1.2"
     deep-clone-merge "^1.5.5"
-    moment "^2.29.4"
-    underscore "^1.13.6"
+    moment "^2.30.1"
+    underscore "^1.13.7"
   optionalDependencies:
-    fsevents "~2.3.2"
+    fsevents "~2.3.3"
 
 hmpo-config@3.0.0:
   version "3.0.0"
@@ -4838,6 +4871,15 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
+junit-report-builder@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/junit-report-builder/-/junit-report-builder-5.1.1.tgz#e4f34cc78515554b06d1132ce4bf5cb2b6244d39"
+  integrity sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==
+  dependencies:
+    lodash "^4.17.21"
+    make-dir "^3.1.0"
+    xmlbuilder "^15.1.1"
+
 just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz"
@@ -5066,7 +5108,7 @@ luxon@3.2.1:
   resolved "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz"
   integrity sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==
 
-make-dir@^3.0.0, make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -5237,7 +5279,7 @@ module-not-found-error@^1.0.1:
   resolved "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz"
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
-moment@^2.29.3, moment@^2.29.4:
+moment@^2.29.3, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
@@ -5256,6 +5298,11 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mustache@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 mz@^2.7.0:
   version "2.7.0"
@@ -5740,6 +5787,11 @@ picocolors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
+
+picocolors@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.0"
@@ -6996,7 +7048,7 @@ underscore@1.12.x:
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz"
   integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
-underscore@^1.13.4, underscore@^1.13.6:
+underscore@^1.13.4, underscore@^1.13.7:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
   integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==


### PR DESCRIPTION

## Proposed changes

This PR contains a new step in the tests. Upon each page loaded: Fraud Check Page. The Axe Accessibility Script will execute against the 'wcg2aa' (WCGA 2.2 AA) ruleset. And report out any violations as warnings.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1514](https://govukverify.atlassian.net/browse/LIME-1514)

All Tests passed locally, no WCGA 2.2 violations detected
![image](https://github.com/user-attachments/assets/2d78770d-ca83-4397-baa4-a9327c082bc3)


[LIME-1514]: https://govukverify.atlassian.net/browse/LIME-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ