### PR TITLE
LIME-1352 Add SIGTERM shutdown, and adjust keepalivetimeout duration to longer than loadbalancer timeout (DCP-4450)

### DIFF
--- a/src/app-setup.js
+++ b/src/app-setup.js
@@ -1,4 +1,4 @@
-const { API, APP, PORT, LOG_LEVEL } = require("./lib/config");
+const { API, APP, LOG_LEVEL } = require("./lib/config");
 
 const commonExpress = require("@govuk-one-login/di-ipv-cri-common-express");
 
@@ -66,7 +66,7 @@ const create = (setup) => {
 
   const { app, router } = setup({
     config: { APP_ROOT: __dirname },
-    port: PORT,
+    port: false,
     logs: loggerConfig,
     session: sessionConfig,
     helmet: helmetConfig,

--- a/src/app-setup.test.js
+++ b/src/app-setup.test.js
@@ -86,7 +86,7 @@ describe("app-setup", () => {
 
       const options = {
         config: { APP_ROOT: __dirname },
-        port: 5030,
+        port: false,
         logs: loggerConfig,
         session: {
           cookieName: "service_session",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 require("express");
 require("express-async-errors");
-
+const { PORT } = require("./lib/config");
 const { setup } = require("hmpo-app");
 const addLanguageParam = require("@govuk-one-login/frontend-language-toggle/build/cjs/language-param-setter.cjs");
 
@@ -19,3 +19,57 @@ app.get("nunjucks").addGlobal("addLanguageParam", addLanguageParam);
 
 AppSetup.init(app, router);
 RoutingService.init(router);
+
+/* Server configuration */
+const server = app.listen(PORT);
+
+// AWS recommends the keep-alive duration of the target is longer than the idle timeout value of the load balancer (default 60s)
+// to prevent possible 502 errors where the target connection has already been closed
+// https://docs.aws.amazon.com/elast
+server.keepAliveTimeout = 65000;
+
+// Handles graceful shutdown of the NODE service, so that if the container is killed by a SIGTERM, it finishes processing existing connections before the server shuts down.
+let serverAlreadyExiting = false;
+let exitCode = 0;
+const MAX_EXIT_WAIT = 30000;
+process.on("SIGTERM", () => {
+  if (serverAlreadyExiting) {
+    // eslint-disable-next-line no-console
+    console.log("SIGTERM signal received: Server close already called");
+    return;
+  }
+  serverAlreadyExiting = true;
+
+  // eslint-disable-next-line no-console
+  console.log("SIGTERM signal received: closing HTTP server");
+
+  // Stop accepting new connections
+  server.close((err) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Error while calling server.close() occurred: ${err.message}`
+      );
+
+      exitCode = 1;
+    } else {
+      // eslint-disable-next-line no-console
+      console.log("HTTP server closed");
+    }
+  });
+
+  // There maybe active timers in the event loop preventing a clean exit.
+  // Give remaining active connections some time to compelte
+  // Then exit, this also closes any connection with keep-alive set
+  setTimeout(() => {
+    // eslint-disable-next-line no-console
+    console.log(`Waiting ${MAX_EXIT_WAIT}ms for before exiting fully`);
+
+    // Close any active connections that have not closed (KeepAlives/Idle etc)
+    server.closeAllConnections();
+
+    // eslint-disable-next-line no-console
+    console.log(`Calling process exit ${exitCode}`);
+    process.exit(exitCode);
+  }, MAX_EXIT_WAIT);
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Add SIGTERM shutdown, and adjust keepalivetimeout duration to longer than loadbalancer timeout

### Why did it change

To implement gracefull shutdown and avoid mismatch between loadbalancer timeout and keepalive.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1352](https://govukverify.atlassian.net/browse/LIME-1352)
- https://govukverify.atlassian.net/browse/DCP-4450
- https://github.com/govuk-one-login/ipv-cri-address-front/pull/1084
- https://github.com/govuk-one-login/ipv-cri-common-express/pull/474

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1352]: https://govukverify.atlassian.net/browse/LIME-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ