### PR TITLE
LIME-1546 - Upgrading FE Vital signs to log max eventLoopDelay

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.1.1",
-    "@govuk-one-login/frontend-vital-signs": "0.1.1",
+    "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axe-playwright": "^2.0.3",
     "axios": "1.7.7",
     "cfenv": "1.2.4",


### PR DESCRIPTION
### What changed
Upgrading FE Vital signs to log max EventLoopDelay (fix brought in by latest patch version)