### PR TITLE
IPS-1428 update sonarcloud version before march deadline

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,7 +61,7 @@ jobs:
           BROWSER: chrome-headless
       - name: Run sonarcloud scan
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # obtained from https://sonarcloud.io
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the sonarcube action

### Why did it change

The existing action is deprecated and due for removal in March

### Issue tracking

- [IPS-1428](https://govukverify.atlassian.net/browse/IPS-1428)

### Other considerations


[IPS-1428]: https://govukverify.atlassian.net/browse/IPS-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ