### PR TITLE
LIME-1637 - Fraud FE - Split out Axe Scan into Specific Tests for better visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon-chai": "3.7.0",
     "uglify-js": "3.19.3",
     "wait-on": "8.0.1",
-    "wiremock": "3.11.0"
+    "wiremock": "3.12.1"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.731.1",

--- a/test/browser/features/errors-check.feature
+++ b/test/browser/features/errors-check.feature
@@ -1,5 +1,5 @@
 @mock-api:fraud-check-error
-Feature: Error handling
+Feature: Fraud CRI - Error handling - Check Error
 
   API Errors in middle of journey
 

--- a/test/browser/features/errors-session.feature
+++ b/test/browser/features/errors-session.feature
@@ -1,5 +1,5 @@
 @mock-api:fraud-session-error
-Feature: Error handling
+Feature: Fraud CRI - Error handling - Session Error
 
   API Errors in middle of journey
 
@@ -11,3 +11,9 @@ Feature: Error handling
   Scenario: API error
     Given they have started the Fraud journey
     Then they should see an error page
+
+  @mock-api:fraud-session-error
+  Scenario: API error
+    Given they have started the Fraud journey
+    Then they should see an error page
+    And I run the Axe Accessibility check against the Fraud Error page

--- a/test/browser/features/fraud.feature
+++ b/test/browser/features/fraud.feature
@@ -76,3 +76,11 @@ Feature: Fraud CRI - Happy Path Tests
     Examples:
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
+      
+  @mock-api:fraud-success
+  Scenario: Fraud CRI - Axe Accessibility Scan - Fraud Check Page
+    Given they have started the Fraud journey
+    And they can see the check page
+    And I run the Axe Accessibility check against the Fraud Check entry page
+    When they continue to fraud check
+    Then they should be redirected as a success

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -8,15 +8,20 @@ const { injectAxe } = require("axe-playwright");
 
 Then("they should see an error page", async function () {
   const errorPage = new ErrorPage(this.page);
-
   const errorTitle = await errorPage.getErrorTitle();
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   expect(errorTitle).to.equal(errorPage.getSomethingWentWrongMessage());
 });
+
+Then(
+  /^I run the Axe Accessibility check against the Fraud Error page$/,
+  async function () {
+    await injectAxe(this.page);
+    // Run Axe for WCAG 2.2 AA rules
+    const wcagResults = await this.page.evaluate(() => {
+      return axe.run({
+        runOnly: ["wcag22aa"]
+      });
+    });
+    expect(wcagResults.violations).to.be.empty;
+  }
+);

--- a/test/browser/step_definitions/fraud.js
+++ b/test/browser/step_definitions/fraud.js
@@ -10,16 +10,22 @@ When(/^they (?:have )?start(?:ed)? the Fraud journey$/, async function () {});
 
 Given(/they (?:can )?see? the check page$/, async function () {
   const checkPage = new CheckPage(this.page);
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
   expect(checkPage.isCurrentPage()).to.be.true;
 });
+
+Given(
+  /^I run the Axe Accessibility check against the Fraud Check entry page$/,
+  async function () {
+    await injectAxe(this.page);
+    // Run Axe for WCAG 2.2 AA rules
+    const wcagResults = await this.page.evaluate(() => {
+      return axe.run({
+        runOnly: ["wcag22aa"]
+      });
+    });
+    expect(wcagResults.violations).to.be.empty;
+  }
+);
 
 Given(/^they (?:have )?continue(?:d)? to fraud check$/, async function () {
   const checkPage = new CheckPage(this.page);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7823,10 +7823,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wiremock@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-3.11.0.tgz#a2f75acecc6a67cd03b51d1cd85ac3ed0124e9ef"
-  integrity sha512-tz2G2DgapRuXVIKDxejCP2ToLt2R83dNgseRgFl5JMM+TJTQWsQGBn7HgHraddYeLIuvJP39+xWww8r6/UZlRg==
+wiremock@3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-3.12.1.tgz#44ff95c8edffeb24c0fd15a7929b9b766a1bc526"
+  integrity sha512-gEJOzFuQTh4emP/bfHPAhL9qLv6LBVn72/jSQKPzNesbp0TT+a/Gx3cSzm0Gc1AGX+WVZ5zFKKemZYMFpqp0mQ==
   dependencies:
     npm-java-runner "^1.0.2"
 


### PR DESCRIPTION
Updated Axe Accessibility Tests:

### What changed
Removed the Axe Scan from the background step of the Scenarios and within Error Page Step Added Specific Test for Passport Details Page and Passport Error Page which runs the Axe Scan

### Why did it change
This will allow for clearer reporting and troubleshooting of any accessibility issues going forward

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes



<!-- Describe the changes in detail - the "what"-->



<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1637](https://govukverify.atlassian.net/browse/LIME-1637)

### Other considerations

Test Evidence: 
![image](https://github.com/user-attachments/assets/74ddd584-31b2-45d0-bab0-ecf1dd25b5ed)



[LIME-1637]: https://govukverify.atlassian.net/browse/LIME-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ