### PR TITLE
LIME-1641 Add Device Intelligence AC Tests to check for Cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/app.js",
-    "start:ci": "API_BASE_URL=http://127.0.0.1:8030/ REDIS_SESSION_URL= NODE_ENV=development node src/app.js",
+    "start:ci": "DEVICE_INTELLIGENCE_ENABLED=true API_BASE_URL=http://127.0.0.1:8030/ REDIS_SESSION_URL= NODE_ENV=development node src/app.js",
     "dev": "LOG_LEVEL=debug nodemon src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",

--- a/test/browser/features/fraud.feature
+++ b/test/browser/features/fraud.feature
@@ -34,7 +34,7 @@ Feature: Fraud CRI - Happy Path Tests
       | ThirdParty     |
       | Privacy Policy |
 
-  @mock-api:fraud-success @test
+  @mock-api:fraud-success
   Scenario Outline: Fraud CRI - Footer Links
     Given they have started the Fraud journey
     And they can see the check page
@@ -66,3 +66,13 @@ Feature: Fraud CRI - Happy Path Tests
     Given they have started the Fraud journey
     Then I select Reject analytics cookies button and see the text You've rejected additional cookies. You can change your cookie settings at any time.
     Then I select the rejected link change your cookie settings and assert I have been redirected correctly
+
+
+  @mock-api:driving-licence-PageCookies @validation-regression
+  Scenario: Driving Licence - Cookies - Device Intelligence
+    Given they have started the Fraud journey
+    And they can see the check page
+    Then I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
+    Examples:
+      | DeviceIntelligenceCookieName |
+      | di-device-intelligence       |

--- a/test/browser/pages/check.js
+++ b/test/browser/pages/check.js
@@ -121,6 +121,7 @@ module.exports = class PlaywrightDevPage {
   }
 
   async assertPrivacyTabs(linkName) {
+    await this.page.waitForLoadState("domcontentloaded");
     await this.whoAreWeSummaryLink.click();
     if (linkName === "ThirdParty") {
       await this.experianLink.click();
@@ -254,5 +255,35 @@ module.exports = class PlaywrightDevPage {
   async continue() {
     this.continueButton.isVisible();
     return this.continueButton.click();
+  }
+
+  async checkDeviceIntelligenceCookie(deviceIntelligenceCookieName) {
+    // Wait for the page to fully load
+    await this.page.waitForLoadState("networkidle", { timeout: 5000 });
+
+    const cookies = await this.page.context().cookies();
+
+    const cookie = cookies.find(
+      (cookie) => cookie.name === deviceIntelligenceCookieName
+    );
+
+    if (!cookie) {
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' not found.`
+      );
+    }
+
+    if (
+      cookie.value === undefined ||
+      cookie.value === null ||
+      cookie.value.trim() === ""
+    ) {
+      // Check for undefined, null, or empty string in value field of the cookie
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' has no value.`
+      );
+    }
+
+    return true;
   }
 };

--- a/test/browser/step_definitions/fraud.js
+++ b/test/browser/step_definitions/fraud.js
@@ -39,6 +39,15 @@ Given(/^they continue to fraud check page$/, async function () {
   expect(checkPage.isCurrentPage()).to.be.false;
 });
 
+Then(
+  /^I see the Device Intelligence Cookie (.*)$/,
+  async function (deviceIntelligenceCookieName) {
+    const checkPage = new CheckPage(this.page);
+
+    await checkPage.checkDeviceIntelligenceCookie(deviceIntelligenceCookieName);
+  }
+);
+
 Given(
   /^they click (.*) and assert I have been directed correctly$/,
   async function (linkName) {


### PR DESCRIPTION
Added new AC Test to check for device Intelligence cookie and that it has a value

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

New AC Test Added to fraud.feature

### Why did it change

To check that the new device intelligence cookie has been loaded correctly after Fraud Check Page load

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1641](https://govukverify.atlassian.net/browse/LIME-1641)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1641]: https://govukverify.atlassian.net/browse/LIME-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ