### PR TITLE
LIME-1721: Removing redundant fields in default yaml files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn install
 - `GA4_NAVIGATION_ENABLED`- Feature flag to enable GA4 navigation tracking, defaulted to `"true"`
 - `GA4_SELECT_CONTENT_ENABLED`- Feature flag to enable GA4 select content tracking, defaulted to `"true"`
 - `LANGUAGE_TOGGLE_DISABLED` - Feature flag to disable Language Toggle, defaulted to `true`
-- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `false`
+- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `true`
 
 ## Pre-Commit Checking / Verification
 

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -2,60 +2,7 @@ buttons:
   next: "Parhau"
   cancel: "Canslo"
 govuk:
-  phaseBanner:
-    tag: beta
-    content: Mae hwn yn wasanaeth newydd – <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">bydd eich adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   serviceName: " "
-  languageToggle:
-    ariaLabel: Dewis iaith
-    englishLanguage: English
-    englishVisuallyHidden: Change to English
-    welshLanguage: Cymraeg
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  backLink: "Yn ôl"
-  errorSummaryTitle: "Mae problem"
-  error: "Gwall"
-  warning: "Rhybudd"
-  skipLink: "Neidio i'r prif gynnwys"
-  betaBannerRequired: true
-  betaBannerContent:
-    betaBannerContentLabel: beta
-    betaBannerContentHTML: Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">adborth (agor mewn tab newydd)</a>  yn ein helpu i''w wella.
-  cookie:
-    cookieBanner:
-      title: Cwcis ar GOV.UK One Login
-      heading: Cwcis ar GOV.UK One Login
-      paragraph1: Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio.
-      paragraph2: Hoffem osod cwcis ychwanegol er mwyn i ni allu cofio eich gosodiadau, deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau.
-      changeCookiePreferencesLink: " newid eich gosodiadau cwcis"
-      cookieBannerAccept:
-        paragraph1: Rydych wedi derbyn cwcis ychwanegol. Gallwch
-        paragraph2: unrhyw bryd.
-      cookieBannerReject:
-        paragraph1: Rydych wedi gwrthod cwcis ychwanegol. Gallwch
-        paragraph2: unrhyw bryd.
-      buttonAcceptText: Derbyn cwcis dadansoddi
-      buttonRejectText: Gwrthod cwcis dadansoddi
-      linkViewCookiesText: Gweld cwcis
-      cookieBannerHideLink: Cuddio'r neges yma
-  footerNavItems:
-    meta:
-      items:
-        - href: "https://signin.account.gov.uk/accessibility-statement"
-          text: "Datganiad hygyrchedd"
-        - href: "https://signin.account.gov.uk/cookies"
-          text: "Cwcis"
-        - href: "https://signin.account.gov.uk/terms-and-conditions"
-          text: "Telerau ac amodau"
-        - href: "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
-          text: "Hysbysiad preifatrwydd"
-        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
-          text: "Cymorth (agor mewn tab newydd)"
-          attributes: { target: "_blank", rel:"noreferrer noopener" }
-  copyright:
-    text: "© Hawlfraint y goron"
-  contentLicence:
-    html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="licence">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'
 
 fraud:
   serviceNameRequired: true

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -2,60 +2,7 @@ buttons:
   next: Continue
   cancel: Cancel
 govuk:
-  phaseBanner:
-    tag: beta
-    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   serviceName: " "
-  languageToggle:
-    ariaLabel: Choose Language
-    englishLanguage: English
-    englishVisuallyHidden: Change to English
-    welshLanguage: Cymraeg
-    welshVisuallyHidden: Newid yr iaith ir Gymraeg
-  backLink: Back
-  errorSummaryTitle: There's a problem
-  error: Error
-  warning: Warning
-  skipLink: Skip to main content
-  betaBannerRequired: true
-  betaBannerContent:
-    betaBannerContentLabel: beta
-    betaBannerContentHTML: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">feedback (opens in new tab)</a>  will help us to improve it.'
-  cookie:
-    cookieBanner:
-      title: Cookies on GOV.UK One Login
-      heading: Cookies on GOV.UK One Login
-      paragraph1: We use some essential cookies to make this service work.
-      paragraph2: We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.
-      changeCookiePreferencesLink: change your cookie settings
-      cookieBannerAccept:
-        paragraph1: "You've accepted additional cookies. You can "
-        paragraph2: " at any time."
-      cookieBannerReject:
-        paragraph1: "You've rejected additional cookies. You can "
-        paragraph2: " at any time."
-      buttonAcceptText: Accept analytics cookies
-      buttonRejectText: Reject analytics cookies
-      linkViewCookiesText: View cookies
-      cookieBannerHideLink: Hide this message
-  footerNavItems:
-    meta:
-      items:
-        - href: "https://signin.account.gov.uk/accessibility-statement"
-          text: "Accessibility statement"
-        - href: "https://signin.account.gov.uk/cookies"
-          text: "Cookies"
-        - href: "https://signin.account.gov.uk/terms-and-conditions"
-          text: "Terms and conditions"
-        - href: "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
-          text: "Privacy notice"
-        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
-          text: "Support (opens in new tab)"
-          attributes: { target: "_blank", rel:"noreferrer noopener" }
-  copyright:
-    text: "© Crown copyright"
-  contentLicence:
-    html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Open Government Licence v3.0</a>, except where otherwise stated'
 
 fraud:
   serviceNameRequired: true


### PR DESCRIPTION
### What changed

Removed redundant fields in default.yml files except for serviceName which is still required for the page title.

### Why did it change

As part of the Branding Refresh, Common Express holds the default fields so these changes have been made to prevent misalignment in the future.

### Issue tracking

- [LIME-1721](https://govukverify.atlassian.net/browse/LIME-1721)

### Other considerations

README file has been changed so that the MAY_2025_REBRAND_ENABLED now defaults to true.


[LIME-1721]: https://govukverify.atlassian.net/browse/LIME-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ