### PR TITLE
LIME-1721: Adding skipLink to default yaml.

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -3,6 +3,7 @@ buttons:
   cancel: "Canslo"
 govuk:
   serviceName: " "
+  skipLink: "Neidio i'r prif gynnwys"
 
 fraud:
   serviceNameRequired: true

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -3,6 +3,7 @@ buttons:
   cancel: Cancel
 govuk:
   serviceName: " "
+  skipLink: Skip to main content
 
 fraud:
   serviceNameRequired: true


### PR DESCRIPTION
### What changed

Added back the skipLink that was removed as part of removing the redundant fields in default yaml.

### Issue tracking

- [LIME-1721](https://govukverify.atlassian.net/browse/LIME-1721)
