### PR TITLE
LIME-1825 - Added new Test for 'skip to main content' link and text

### DIFF
--- a/test/browser/features/fraud.feature
+++ b/test/browser/features/fraud.feature
@@ -63,8 +63,20 @@ Feature: Fraud CRI - Happy Path Tests
     Given I select Reject analytics cookies button and see the text You've rejected additional cookies. You can change your cookie settings at any time.
     Then I select the rejected link change your cookie settings and assert I have been redirected correctly
 
-  @mock-api:driving-licence-PageCookies @validation-regression
-  Scenario: Driving Licence - Cookies - Device Intelligence
+  @mock-api:fraud-success
+  Scenario: Fraud CRI - Skip to Main Content
+    Given they can see the check page
+    Then I see the Skip to main content Link Text
+
+  @mock-api:fraud-success
+  Scenario: Fraud CRI - User Clicks the View Cookies on the Cookie Banner
+    Given they can see the check page
+    And The cookie banner is displayed
+    When User clicks on the View Cookies Link
+    And I check the Cookies page Title GOV.UK One Login cookies policy
+
+ @mock-api:fraud-success
+  Scenario: Fraud CRI - Cookies - Device Intelligence
     And they can see the check page
     Then I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
     Examples:

--- a/test/browser/pages/check.js
+++ b/test/browser/pages/check.js
@@ -19,6 +19,16 @@ module.exports = class PlaywrightDevPage {
       hasText: "Read our privacy notice (opens in new tab)"
     });
     this.continueButton = this.page.locator('xpath=//*[@id="continue"]');
+    this.skipToMainContent = this.page.locator("xpath=//html/body/a");
+    this.cookieBanner = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]'
+    );
+    this.viewCookiesLink = this.page.locator(
+      'xpath=//*[@id="cookies-banner-main"]/div[2]/a'
+    );
+    this.cookiesPageTitle = this.page.locator(
+      'xpath=//*[@id="main-content"]/div/div/h1'
+    );
     this.supportLink = this.page.locator(
       "xpath=/html/body/footer/div/div/div[1]/ul/li[5]/a"
     );
@@ -75,7 +85,7 @@ module.exports = class PlaywrightDevPage {
       'xpath=//*[@id="main-content"]/div/div/form/p[2]'
     );
     this.fraudLandingPageWarningMessageText = this.page.locator(
-      'xpath=//*[@id="main-content"]/div/div/form/p[3]/text()'
+      'xpath=//*[@id="main-content"]/div/div/form/p[3]'
     );
   }
 
@@ -88,6 +98,9 @@ module.exports = class PlaywrightDevPage {
     await this.fraudLandingPageTitleSummary.isVisible(
       fraudLandingPageTitleSummary
     );
+    await expect(
+      await this.fraudLandingPageTitleSummary.textContent()
+    ).to.contains(fraudLandingPageTitleSummary);
   }
 
   async assertFraudLandingPageTitleSummaryTextOne(
@@ -97,6 +110,9 @@ module.exports = class PlaywrightDevPage {
     await this.fraudLandingPageTitleSummaryTextOne.isVisible(
       fraudLandingPageTitleSummaryTextOne
     );
+    await expect(
+      await this.fraudLandingPageTitleSummaryTextOne.textContent()
+    ).to.contains(fraudLandingPageTitleSummaryTextOne);
   }
 
   async assertFraudLandingPageTitleSummaryTextTwo(
@@ -106,6 +122,9 @@ module.exports = class PlaywrightDevPage {
     await this.fraudLandingPageTitleSummaryTextTwo.isVisible(
       fraudLandingPageTitleSummaryTextTwo
     );
+    await expect(
+      await this.fraudLandingPageTitleSummaryTextTwo.textContent()
+    ).to.contains(fraudLandingPageTitleSummaryTextTwo);
   }
 
   async getDoNotRefreshPageMessage(fraudLandingPageWarningMessage) {
@@ -113,6 +132,9 @@ module.exports = class PlaywrightDevPage {
     await this.fraudLandingPageWarningMessageText.isVisible(
       fraudLandingPageWarningMessage
     );
+    await expect(
+      await this.fraudLandingPageWarningMessageText.textContent()
+    ).to.contains(fraudLandingPageWarningMessage);
   }
 
   async assertPrivacyTabs(linkName) {
@@ -214,7 +236,6 @@ module.exports = class PlaywrightDevPage {
   }
 
   async assertBetaBannerText(betaBannerText) {
-    expect(await this.isCurrentPage()).to.be.true;
     expect(await this.betaBanner.innerText()).to.equal(betaBannerText);
   }
 
@@ -265,6 +286,32 @@ module.exports = class PlaywrightDevPage {
     let context = await this.page.context();
     let pages = context.pages();
     expect(pages[0].url()).to.equal("https://signin.account.gov.uk/cookies");
+  }
+
+  async cookieBannerDisplayed() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookieBanner.isVisible();
+  }
+
+  async clickViewCookiesLink() {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.viewCookiesLink.click();
+  }
+
+  async assertCookiesPolicyPageTitle(cookiesPageTitle) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.cookiesPageTitle.isVisible(cookiesPageTitle);
+    expect(await this.cookiesPageTitle.textContent()).to.contains(
+      cookiesPageTitle
+    );
+  }
+
+  async assertSkipToMainContent(skipToMainContent) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.skipToMainContent.textContent(skipToMainContent);
+    expect(await this.skipToMainContent.textContent()).to.contains(
+      skipToMainContent
+    );
   }
 
   async waitForSpinner() {

--- a/test/browser/step_definitions/fraud.js
+++ b/test/browser/step_definitions/fraud.js
@@ -118,6 +118,29 @@ Then(
   }
 );
 
+Given(/^The cookie banner is displayed$/, async function () {
+  const checkPage = new CheckPage(this.page);
+  await checkPage.cookieBannerDisplayed();
+});
+
+When(/^User clicks on the View Cookies Link$/, async function () {
+  const checkPage = new CheckPage(this.page);
+  await checkPage.clickViewCookiesLink();
+});
+
+Then(
+  /^I check the Cookies page Title (.*)$/,
+  async function (cookiesPageTitle) {
+    const checkPage = new CheckPage(this.page);
+    await checkPage.assertCookiesPolicyPageTitle(cookiesPageTitle);
+  }
+);
+
+Then(/^I see the (.*) Link Text$/, async function (skipToMainContent) {
+  const checkPage = new CheckPage(this.page);
+  await checkPage.assertSkipToMainContent(skipToMainContent);
+});
+
 Then(
   /^they can see the check page title text as (.*)$/,
   async function (fraudLandingPageTitleSummary) {


### PR DESCRIPTION
- New Test added for the Skip to Main Content Link to validate it has the correct Text values (in relation to the work completed in LIME-1721)
- New Test added to check the 'View Cookies' Link on the cooker banner has the correct text value and opens the correct link

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1825](https://govukverify.atlassian.net/browse/LIME-1825)
- [LIME-1721](https://govukverify.atlassian.net/browse/LIME-1721)

### Other considerations

All Tests passing locally:

![Uploading image.png…]()


[LIME-1825]: https://govukverify.atlassian.net/browse/LIME-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1721]: https://govukverify.atlassian.net/browse/LIME-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ