### PR TITLE
LIME-1719: Updating README to MAY_2025_REBRAND_ENABLED defaults to fa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn install
 - `GA4_NAVIGATION_ENABLED`- Feature flag to enable GA4 navigation tracking, defaulted to `"true"`
 - `GA4_SELECT_CONTENT_ENABLED`- Feature flag to enable GA4 select content tracking, defaulted to `"true"`
 - `LANGUAGE_TOGGLE_DISABLED` - Feature flag to disable Language Toggle, defaulted to `true`
-- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `true`
+- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `false`
 
 ## Pre-Commit Checking / Verification
 


### PR DESCRIPTION
### What changed

README now indicates that MAY_2025_REBRAND_ENABLED feature flag defaults to false.

### Issue tracking

- [LIME-1719](https://govukverify.atlassian.net/browse/LIME-1719)


[LIME-1719]: https://govukverify.atlassian.net/browse/LIME-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ