### PR TITLE
LIME-2127: Add the workflows to push testing images to Dev, Build and Staging.

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -33,6 +33,26 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 #v3.10.1
+        with:
+          cosign-release: "v2.5.1"
+
+      - name: "Build, tag, and push testing images to Amazon ECR"
+        env:
+          CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_BUILD: ${{ secrets.ECR_REPOSITORY_BUILD_TEST }}
+          ECR_REPOSITORY_STAGING: ${{ secrets.ECR_REPOSITORY_STAGING_TEST }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG -f test/Dockerfile .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
+          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -32,6 +32,23 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 #v3.10.1
+        with:
+          cosign-release: "v2.5.1"
+
+      - name: Build, tag, and push testing images to Amazon ECR
+        env:
+          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY_DEV: ${{ secrets.ECR_REPOSITORY_DEV_TEST }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG -f test/Dockerfile .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:


### PR DESCRIPTION

## Proposed changes

### What changed

- Add new step inside `post-merge-to-dev.yml` action to push the testing image to Dev environment
- Add new step inside `post-merge-to-build.yml` action to push the testing image to Build and Staging environments

### Why did it change

- To create a Test step in Dev, Build and Staging in Fraud Frontend

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2127](https://govukverify.atlassian.net/browse/LIME-2127)



[LIME-2127]: https://govukverify.atlassian.net/browse/LIME-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ