### PR TITLE
BAU remove redundant playwright setup step in pr check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,10 +69,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install chromium --with-deps
 
-      - name: Setup Playwright dependencies
-        run: yarn playwright install-deps chromium
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-
       - name: Build assets
         run: yarn build
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

- pr checks workflow no longer requires an additional playwright dependencies setup step

### Why did it change

- this step was slow and unreliable so has been removed