### PR TITLE
BAU add explicit SAM CLI setup to post-merge workflows and fix CI job dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,9 @@ jobs:
     permissions:
       contents: write
       packages: write
-    needs: resolve-test-versions
+    needs:
+      - resolve-test-versions
+      - pre-commit
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -24,6 +24,12 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        with:
+          use-installer: true
+          version: "1.157.1"
+
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -25,6 +25,12 @@ jobs:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        with:
+          use-installer: true
+          version: "1.157.1"
+
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add setup-sam step to post-merge-to-dev and post-merge-to-build workflows
  so SAM validate has the CLI available
- Remove SAM validate from pre-commit job in checks workflow (not needed there)
- Make run-premerge-checks depend on pre-commit job completing first

### Why did it change

To enable pining sam to a known version where its used.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

BAU

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
