### PR TITLE
LIME-1551 Align Canary stack healthcheck config

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -147,23 +147,23 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 607
+        "line_number": 610
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 608
+        "line_number": 611
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 610
+        "line_number": 613
       }
     ]
   },
-  "generated_at": "2026-05-22T09:47:11Z"
+  "generated_at": "2026-06-04T08:11:53Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -309,6 +309,9 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
+      HealthCheckTimeoutSeconds: 2
+      HealthCheckIntervalSeconds: 5
+      HealthyThresholdCount: 2
       Matcher:
         HttpCode: 200
       Port: 80


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Aligned healthcheck config settings

### Why did it change

Needed the green target group to have the same healthcheck configuration as the blue target group 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1551](https://govukverify.atlassian.net/browse/LIME-1551)



[LIME-1551]: https://govukverify.atlassian.net/browse/LIME-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ