### PR TITLE
LIME-2133 - Fraud - Updated Axe Accessibility Coverage

### DIFF
--- a/test/browser/features/wiremock_features/WelshLangFraudCRI.feature
+++ b/test/browser/features/wiremock_features/WelshLangFraudCRI.feature
@@ -28,3 +28,10 @@ Feature: Fraud CRI - Welsh Language Test
     When they view the Beta banner with the Welsh text as Mae hwn yn wasanaeth newydd. Helpwch ni i'w wella a rhoi eich adborth (agor mewn tab newydd).
     Then I select Reject analytics cookies button and see the text Rydych wedi gwrthod cwcis ychwanegol. Gallwch newid eich gosodiadau cwcis ar unrhyw adeg.
     Then I select the rejected link change your cookie settings and assert I have been redirected correctly
+
+  @QualityGateAccessibilityTest
+  @mock-api:fraud-success
+  Scenario: Fraud CRI - Axe Accessibility Scan - Fraud Check Page Welsh
+    And I run the Axe Accessibility check against the Fraud Check entry page
+    When they continue to fraud check page
+    Then they should be redirected as a success

--- a/test/browser/step_definitions/wiremock_steps/errors.js
+++ b/test/browser/step_definitions/wiremock_steps/errors.js
@@ -13,7 +13,7 @@ Then(
   /^I run the Axe Accessibility check against the Fraud Error page$/,
   async function () {
     const results = await new AxeBuilder({ page: this.page })
-      .withTags(["wcag22aa"])
+      .withTags(["wcag22aa", "best-practice"])
       .analyze();
 
     expect(results.violations).to.be.empty;

--- a/test/browser/step_definitions/wiremock_steps/fraud.js
+++ b/test/browser/step_definitions/wiremock_steps/fraud.js
@@ -12,7 +12,7 @@ Given(
   /^I run the Axe Accessibility check against the Fraud Check entry page$/,
   async function () {
     const results = await new AxeBuilder({ page: this.page })
-      .withTags(["wcag22aa"])
+      .withTags(["wcag22aa", "best-practice"])
       .analyze();
 
     expect(results.violations).to.be.empty;


### PR DESCRIPTION
Added best-practice tag alongside wcag22aa tag
Added accessibility test for the check page when in Welsh

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

best-practice tag added to the Axe Accessibility Check Step
Welsh Page tests added with Axe Accessibility Coverage on the Fraud Check Page

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2133](https://govukverify.atlassian.net/browse/LIME-2133)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2133]: https://govukverify.atlassian.net/browse/LIME-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ