### PR TITLE
test(browser): default step timeout + passthrough headers coverage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,7 +65,13 @@ export default [
           args: "after-used",
           varsIgnorePattern: "Given|And|When|Then"
         }
-      ],
+      ]
+    }
+  },
+  {
+    files: ["test/browser/support/setup.js"],
+    rules: {
+      "no-console": "off"
     }
   }
 ];

--- a/test/browser/cucumber.js
+++ b/test/browser/cucumber.js
@@ -3,7 +3,6 @@ const path = require("path");
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 
-const DEFAULT_TIMEOUT = 60 * 1000;
 const PROGRESS = "progress";
 
 const commonSupport = ["./test/browser/support/**/*.js"];
@@ -26,8 +25,7 @@ module.exports = {
       PROGRESS,
       `json:${makeReportPath("cucumber-report.json")}`,
       `html:${makeReportPath("index.html")}`
-    ],
-    timeout: DEFAULT_TIMEOUT
+    ]
   },
 
   stub_tests: {
@@ -40,8 +38,7 @@ module.exports = {
       PROGRESS,
       `json:${makeReportPath("cucumber-stub-report.json")}`,
       `html:${makeReportPath("stub-index.html")}`
-    ],
-    timeout: DEFAULT_TIMEOUT
+    ]
   },
 
   wiremock_tests: {
@@ -51,7 +48,6 @@ module.exports = {
       PROGRESS,
       `json:${makeReportPath("cucumber-wiremock-report.json")}`,
       `html:${makeReportPath("wiremock-index.html")}`
-    ],
-    timeout: DEFAULT_TIMEOUT
+    ]
   }
 };

--- a/test/browser/features/wiremock-features/journey-resilience.feature
+++ b/test/browser/features/wiremock-features/journey-resilience.feature
@@ -21,3 +21,10 @@ Feature: Fraud CRI - Journey Resilience
     When they continue to fraud check
     Then they should be redirected as a success
     And the backend received the identity-check request with the session_id header
+
+  @mock-api:fraud-success
+  Scenario: The identity-check request carries the txma-audit-encoded header
+    Given they can see the check page
+    When they continue to fraud check
+    Then they should be redirected as a success
+    And the backend received the identity-check request with the txma-audit-encoded header

--- a/test/browser/step-definitions/wiremock-steps/journey-resilience.js
+++ b/test/browser/step-definitions/wiremock-steps/journey-resilience.js
@@ -1,7 +1,9 @@
 const { When, Then } = require("@cucumber/cucumber");
 const { expect } = require("chai");
-const axios = require("axios");
-const ConfigurationReader = require("../../support/configuration-reader");
+const {
+  findWiremockRequest,
+  getHeaderCaseInsensitive
+} = require("../../support/wiremock-assertions");
 
 When("they reload the check page", async function () {
   await this.page.reload({ waitUntil: "domcontentloaded" });
@@ -10,25 +12,43 @@ When("they reload the check page", async function () {
 Then(
   "the backend received the identity-check request with the session_id header",
   async function () {
-    const baseUrl = ConfigurationReader.get("API_BASE_URL");
-    const res = await axios.get(`${baseUrl}__admin/requests`);
+    const entry = await findWiremockRequest({
+      method: "POST",
+      url: "/identity-check"
+    });
 
-    const identityCheckRequest = res.data.requests.find(
-      (entry) =>
-        entry.request.method === "POST" &&
-        entry.request.url === "/identity-check"
-    );
-
-    expect(identityCheckRequest, "no POST /identity-check captured by wiremock")
+    expect(entry, "expected wiremock to have captured a POST /identity-check")
       .to.exist;
 
-    const headers = identityCheckRequest.request.headers || {};
-    const sessionIdHeader = Object.keys(headers).find(
-      (name) => name.toLowerCase() === "session_id"
+    const sessionId = getHeaderCaseInsensitive(
+      entry.request.headers,
+      "session_id"
     );
+    expect(
+      sessionId,
+      "expected session_id header on /identity-check to equal ABADCAFE"
+    ).to.equal("ABADCAFE");
+  }
+);
 
-    expect(sessionIdHeader, "session_id header missing from /identity-check").to
-      .exist;
-    expect(headers[sessionIdHeader]).to.equal("ABADCAFE");
+Then(
+  "the backend received the identity-check request with the txma-audit-encoded header",
+  async function () {
+    const entry = await findWiremockRequest({
+      method: "POST",
+      url: "/identity-check"
+    });
+
+    expect(entry, "expected wiremock to have captured a POST /identity-check")
+      .to.exist;
+
+    const txma = getHeaderCaseInsensitive(
+      entry.request.headers,
+      "txma-audit-encoded"
+    );
+    expect(
+      txma,
+      `expected txma-audit-encoded header on /identity-check to equal ${this.testTxmaAuditEncoded}`
+    ).to.equal(this.testTxmaAuditEncoded);
   }
 );

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -1,7 +1,15 @@
-const { Before, BeforeAll, AfterAll, After } = require("@cucumber/cucumber");
+const {
+  Before,
+  BeforeAll,
+  AfterAll,
+  After,
+  setDefaultTimeout
+} = require("@cucumber/cucumber");
 const { chromium } = require("@playwright/test");
 const axios = require("axios");
 const ConfigurationReader = require("./configuration-reader");
+
+setDefaultTimeout(60 * 1000);
 
 BeforeAll(async function () {
   // Log environment at start of test execution (only for stub tests)
@@ -11,10 +19,8 @@ BeforeAll(async function () {
   ) {
     try {
       const testEnvironment = ConfigurationReader.get("ENVIRONMENT");
-      // eslint-disable-next-line no-console
       console.log(`Running tests for environment: ${testEnvironment}`);
     } catch {
-      // eslint-disable-next-line no-console
       console.log("ENVIRONMENT not configured");
     }
   }
@@ -44,7 +50,6 @@ Before(async function ({ pickle } = {}) {
   // Determine if this is a stub test based on the tag @stub-test
   this.isStubTest = tags.find((tag) => tag.name === "@stub-test");
 
-  // eslint-disable-next-line no-console
   console.log(`\nRunning: ${pickle.name}`);
 
   // Existing logic for WireMock scenario header and reset
@@ -58,7 +63,6 @@ Before(async function ({ pickle } = {}) {
       try {
         await axios.get(url);
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.log(`Warning: Failed to reset mock API: ${error.message}`);
       }
     }
@@ -76,11 +80,11 @@ Before(async function () {
     contextOptions.baseURL = ConfigurationReader.get("API_BASE_URL");
   }
 
-  // Apply scenario ID header if present
   if (this.SCENARIO_ID_HEADER) {
+    this.testTxmaAuditEncoded = "test-txma-audit-encoded-value";
     contextOptions.extraHTTPHeaders = {
-      ...contextOptions.extraHTTPHeaders, // Preserve any existing headers
-      "x-scenario-id": this.SCENARIO_ID_HEADER
+      "x-scenario-id": this.SCENARIO_ID_HEADER,
+      "txma-audit-encoded": this.testTxmaAuditEncoded
     };
   }
 

--- a/test/browser/support/wiremock-assertions.js
+++ b/test/browser/support/wiremock-assertions.js
@@ -1,0 +1,27 @@
+const axios = require("axios");
+const ConfigurationReader = require("./configuration-reader");
+
+async function fetchWiremockRequests() {
+  const baseUrl = ConfigurationReader.get("API_BASE_URL");
+  const res = await axios.get(`${baseUrl}__admin/requests`);
+  return res.data.requests || [];
+}
+
+async function findWiremockRequest({ method, url }) {
+  const requests = await fetchWiremockRequests();
+  return requests.find(
+    (entry) => entry.request.method === method && entry.request.url === url
+  );
+}
+
+function getHeaderCaseInsensitive(headers, name) {
+  const matchKey = Object.keys(headers || {}).find(
+    (key) => key.toLowerCase() === name.toLowerCase()
+  );
+  return matchKey ? headers[matchKey] : undefined;
+}
+
+module.exports = {
+  findWiremockRequest,
+  getHeaderCaseInsensitive
+};


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

- drop incorrect `timeout: DEFAULT_TIMEOUT` lines + unused constant, set default timeout in setup
- add createPersonalDataHeaders passthrough coverage
  - refactor journey-resilience step defs onto the assertions helper
  - new scenario asserts txma-audit-encoded reaches /identity-check
- eslint: allow no-console in test/browser/setup.js

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
