### PR TITLE
LIME-2124: Update workflows to use latest devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -33,31 +33,29 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
-      # Likely source of node warning
-      # https://github.com/aws-actions/amazon-ecr-login/issues/586
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 #v3.10.1
+      - name: Test image build and push (build)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
-          cosign-release: "v2.5.1"
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_BUILD_TEST }}
+          dockerfile: test/Dockerfile
+          docker-build-path: .
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
-      - name: "Build, tag, and push testing images to Amazon ECR"
-        env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_BUILD: ${{ secrets.ECR_REPOSITORY_BUILD_TEST }}
-          ECR_REPOSITORY_STAGING: ${{ secrets.ECR_REPOSITORY_STAGING_TEST }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG -f test/Dockerfile .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
-          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
-          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+      - name: Test image build and push (staging)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_STAGING_TEST }}
+          dockerfile: test/Dockerfile
+          docker-build-path: .
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -66,8 +64,8 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@156ca69f253c67f2f71488d0d81f7a3d97657e43 # v1.6.1
+      - name: App image build and push
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET }}
           container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -34,26 +34,17 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 #v3.10.1
+      - name: Test image build and push
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
-          cosign-release: "v2.5.1"
-
-      - name: Build, tag, and push testing images to Amazon ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_DEV: ${{ secrets.ECR_REPOSITORY_DEV_TEST }}
-          IMAGE_TAG: latest
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG -f test/Dockerfile .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-          cosign sign --yes --tlog-upload=false --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_DEV_TEST }}
+          dockerfile: test/Dockerfile
+          docker-build-path: .
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
       - name: Login to GDS Dev Dynatrace Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -62,8 +53,8 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
-      - name: "Push signed image to ECR, updated SAM template with image then upload it to the S3 Artifact Bucket"
-        uses: govuk-one-login/devplatform-upload-action-ecr@156ca69f253c67f2f71488d0d81f7a3d97657e43 # v1.6.1
+      - name: App image build and push
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET }}
           container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}


### PR DESCRIPTION
## Proposed changes

### What changed

- Move from manual steps to build and deploy ECR repos back to the `devplatform-upload-action-ecr` action
- Remove steps `Login to Amazon ECR`, `Install Cosign` and `Create shared signing config` as they are now handled by the `devplatform-upload-action-ecr` action

### Why did it change

- Move back to the `devplatform-upload-action-ecr` action instead of using a manual workflow

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2124](https://govukverify.atlassian.net/browse/LIME-2124)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->

[LIME-2124]: https://govukverify.atlassian.net/browse/LIME-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ